### PR TITLE
パンくず機能実装

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -84,3 +84,4 @@ gem 'carrierwave'
 gem 'mini_magick'
 gem 'fog-aws'
 gem 'ancestry'
+gem "gretel"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -143,6 +143,8 @@ GEM
     formatador (0.2.5)
     globalid (0.4.2)
       activesupport (>= 4.2.0)
+    gretel (3.0.9)
+      rails (>= 3.1.0)
     haml (5.1.2)
       temple (>= 0.8.0)
       tilt
@@ -351,6 +353,7 @@ DEPENDENCIES
   faker (~> 2.8)
   fog-aws
   font-awesome-sass
+  gretel
   haml-rails
   jbuilder (~> 2.5)
   jquery-rails

--- a/app/assets/stylesheets/_categories.scss
+++ b/app/assets/stylesheets/_categories.scss
@@ -9,6 +9,7 @@
   width: 700px;
   &__title {
     font-size: 22px;
+    padding-top: 50px;
   }
   &__parents {
     margin: 10px 15px;

--- a/app/assets/stylesheets/_mypage.scss
+++ b/app/assets/stylesheets/_mypage.scss
@@ -201,9 +201,9 @@
   box-shadow: 0 3px 3px 0 rgba(0,0,0,0.16);
   background: #fff;
   z-index: 1;
-  &--link {
+  &--link a{
     text-decoration: none;
-    color: #333;
+    color: #000;
   }
 }
 

--- a/app/views/categories/index.html.haml
+++ b/app/views/categories/index.html.haml
@@ -1,3 +1,5 @@
+- breadcrumb :category_list
+= render 'shared/nav_bar'
 .categories
   .categories__title
     カテゴリ一覧

--- a/app/views/categories/show.html.haml
+++ b/app/views/categories/show.html.haml
@@ -1,3 +1,5 @@
+- breadcrumb :category_show, @category
+= render 'shared/nav_bar'
 .categories-list
   .categories-list__title
     = @category.category

--- a/app/views/items/edit.html.haml
+++ b/app/views/items/edit.html.haml
@@ -1,1 +1,3 @@
+- breadcrumb :item_edit
+= render 'shared/nav_bar'
 = render partial: 'form', locals: {submit_value: "変更する"}

--- a/app/views/items/new.html.haml
+++ b/app/views/items/new.html.haml
@@ -1,1 +1,3 @@
+- breadcrumb :exhibition
+= render 'shared/nav_bar'
 = render partial: 'form', locals: {submit_value: "出品する"}

--- a/app/views/items/show.html.haml
+++ b/app/views/items/show.html.haml
@@ -1,3 +1,5 @@
+- breadcrumb :item_show
+= render 'shared/nav_bar'
 .details
   .detail-box
     .detail-box-heading

--- a/app/views/shared/_nav_bar.html.haml
+++ b/app/views/shared/_nav_bar.html.haml
@@ -1,7 +1,6 @@
 .mypage-nav-bar
   %ul
-    %li 
-      = link_to 'FURIMA', root_path, class:"mypage-nav-bar--link"
-    %li ＞
-    %li マイページ
+    %li
+      = breadcrumbs pretext: "",separator: " ＞ ", class: "mypage-nav-bar--link"
+
 

--- a/app/views/users/exhibitor_complete.html.haml
+++ b/app/views/users/exhibitor_complete.html.haml
@@ -1,1 +1,2 @@
+- breadcrumb :exhibitor_complete
 = render partial: 'exhibitor', locals: {tab_index: 3}

--- a/app/views/users/exhibitor_progress.html.haml
+++ b/app/views/users/exhibitor_progress.html.haml
@@ -1,1 +1,2 @@
+- breadcrumb :exhibitor_progress
 = render partial: 'exhibitor', locals: {tab_index: 2}

--- a/app/views/users/exhibitor_sale.html.haml
+++ b/app/views/users/exhibitor_sale.html.haml
@@ -1,1 +1,2 @@
+- breadcrumb :exhibitor_sale
 = render partial: 'exhibitor', locals: {tab_index: 1}

--- a/app/views/users/index.html.haml
+++ b/app/views/users/index.html.haml
@@ -1,3 +1,4 @@
+- breadcrumb :mypage
 = render 'shared/nav_bar'
 .mypage
   .mypage__content

--- a/app/views/users/info_notice.html.haml
+++ b/app/views/users/info_notice.html.haml
@@ -1,1 +1,2 @@
+- breadcrumb :info_notice
 = render partial: 'info', locals: {tab_index: 1}

--- a/app/views/users/info_todo.html.haml
+++ b/app/views/users/info_todo.html.haml
@@ -1,1 +1,2 @@
+- breadcrumb :info_todo
 = render partial: 'info', locals: {tab_index: 2}

--- a/app/views/users/logout.html.haml
+++ b/app/views/users/logout.html.haml
@@ -1,3 +1,4 @@
+- breadcrumb :logout
 = render 'shared/nav_bar'
 .mypage
   .mypage__content

--- a/app/views/users/purchase_complete.html.haml
+++ b/app/views/users/purchase_complete.html.haml
@@ -1,1 +1,2 @@
+- breadcrumb :purchase_complete
 = render partial: 'purchase', locals: {tab_index: 2}

--- a/app/views/users/purchase_progress.html.haml
+++ b/app/views/users/purchase_progress.html.haml
@@ -1,1 +1,2 @@
+- breadcrumb :purchase_progress
 = render partial: 'purchase', locals: {tab_index: 1}

--- a/config/breadcrumbs.rb
+++ b/config/breadcrumbs.rb
@@ -1,0 +1,93 @@
+crumb :root do
+  link "FURIMA", root_path
+end
+
+crumb :mypage do
+  link "マイページ", users_path
+end
+
+crumb :info_notice do
+  link "お知らせ"
+  parent :mypage
+end
+
+crumb :info_todo do
+  link "やることリスト"
+  parent :mypage
+end
+
+crumb :exhibitor_sale do
+  link "出品した商品-出品中-"
+  parent :mypage
+end
+
+crumb :exhibitor_progress do
+  link "出品した商品-取引中-"
+  parent :mypage
+end
+
+crumb :exhibitor_complete do
+  link "出品した商品-売却済み-"
+  parent :mypage
+end
+
+crumb :purchase_progress do
+  link "購入した商品-取引中-"
+  parent :mypage
+end
+
+crumb :purchase_complete do
+  link "購入した商品-過去の取引-"
+  parent :mypage
+end
+
+crumb :logout do
+  link "ログアウト"
+  parent :mypage
+end
+
+crumb :exhibition do
+  link "出品する"
+end
+
+crumb :item_show do
+  link "商品詳細ページ"
+end
+
+crumb :item_edit do
+  link "出品情報編集ページ"
+end
+
+crumb :category_list do
+  link "カテゴリ一覧", categories_path
+end
+
+crumb :category_show do |category|
+  link "#{category.category}"
+  parent :category_list
+end
+
+# crumb :projects do
+#   link "Projects", projects_path
+# end
+
+# crumb :project do |project|
+#   link project.name, project_path(project)
+#   parent :projects
+# end
+
+# crumb :project_issues do |project|
+#   link "Issues", project_issues_path(project)
+#   parent :project, project
+# end
+
+# crumb :issue do |issue|
+#   link issue.title, issue_path(issue)
+#   parent :project_issues, issue.project
+# end
+
+# If you want to split your breadcrumbs configuration over multiple files, you
+# can create a folder named `config/breadcrumbs` and put your configuration
+# files there. All *.rb files (e.g. `frontend.rb` or `products.rb`) in that
+# folder are loaded and reloaded automatically when you change them, just like
+# this file (`config/breadcrumbs.rb`).


### PR DESCRIPTION
#  What
`gretel `というgemを使用し、パンくず機能を実装する。
パンくず部分テンプレを`_nav_bar`に設定し`breadcrumbs.rb`にルーティングを記述、
表示したい各ビューに読み込む形で実装。

（もう少し改善の余地はあるかと思いますが、一旦実装とさせて頂きます。）

# Why
フリマアプリにおいてユーザが今どこにいるかを可視化するで利便性が向上する。