### PR TITLE
アクセス制限の付加

### DIFF
--- a/app/assets/stylesheets/modules/cards.scss
+++ b/app/assets/stylesheets/modules/cards.scss
@@ -22,7 +22,7 @@
   background-color: #3ccace;
   margin: 0 auto;
 }
-input[type= "text"] {
+.cardinfo_text {
   width: 200px;
   height: 30px;
 }

--- a/app/controllers/cards_controller.rb
+++ b/app/controllers/cards_controller.rb
@@ -5,7 +5,6 @@ class CardsController < ApplicationController
     card = Card.where(user_id: current_user.id)
     redirect_to card_path(card.first.id) if card.exists?
     @payjp_public_key = ENV["PAYJP_KEY"]
-    # binding.pry
   end
 
   def create

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,4 +1,5 @@
 class ItemsController < ApplicationController
+  before_action :move_to_index, except: [:index, :show, :edit]
   before_action :set_item, only: [:edit, :show, :update, :destroy]
 
   # トップページ
@@ -31,6 +32,7 @@ class ItemsController < ApplicationController
 
   # 商品情報編集ページ
   def edit
+    redirect_to item_path(@item) if @item.user_id != current_user.id || @item.status > 0
   end
   
   def update
@@ -43,6 +45,7 @@ class ItemsController < ApplicationController
 
   # 商品削除
   def destroy
+    redirect_to root_path if @item.user_id != current_user.id
     if @item.destroy
       redirect_to root_path
     else
@@ -79,5 +82,9 @@ class ItemsController < ApplicationController
 
   def set_item
     @item = Item.find(params[:id])
+  end
+
+  def move_to_index
+    redirect_to root_path unless user_signed_in?
   end
 end

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,5 +1,5 @@
 class ItemsController < ApplicationController
-  before_action :move_to_index, except: [:index, :show, :edit]
+  before_action :move_to_user_registration, except: [:index, :show]
   before_action :set_item, only: [:edit, :show, :update, :destroy]
 
   # トップページ
@@ -30,9 +30,9 @@ class ItemsController < ApplicationController
     @category = Category.find(params[:id])
   end
 
-  # 商品情報編集ページ
+  # 商品情報編集ページ（編集できるのは出品者であること、かつ、取引が成立していないこと）
   def edit
-    redirect_to item_path(@item) if @item.user_id != current_user.id || @item.status > 0
+    redirect_to item_path(@item) unless @item.user_id == current_user.id && @item.status == 0
   end
   
   def update
@@ -43,9 +43,9 @@ class ItemsController < ApplicationController
     end
   end
 
-  # 商品削除
+  # 商品削除（削除できるのは出品者であること、かつ、取引が成立していないこと）
   def destroy
-    redirect_to root_path if @item.user_id != current_user.id
+    redirect_to root_path unless @item.user_id == current_user.id && @item.status == 0
     if @item.destroy
       redirect_to root_path
     else
@@ -84,7 +84,7 @@ class ItemsController < ApplicationController
     @item = Item.find(params[:id])
   end
 
-  def move_to_index
-    redirect_to root_path unless user_signed_in?
+  def move_to_user_registration
+    redirect_to new_user_registration_path unless user_signed_in?
   end
 end

--- a/app/controllers/orders_controller.rb
+++ b/app/controllers/orders_controller.rb
@@ -2,6 +2,7 @@ class OrdersController < ApplicationController
   require 'payjp'
   
   before_action :set_order, only: [:show, :update]
+  before_action :move_to_index
   before_action :set_item, only: [:new, :create, :update]
 
   # 商品購入確認ページ
@@ -34,10 +35,10 @@ class OrdersController < ApplicationController
   end
 
   def show
+    redirect_to root_path if @order.user_id != current_user.id && @order.item.user_id != current_user.id
   end
   
   def update
-    # @item = Item.find(params[:item_id])
     if @item.update(status: 2)
       redirect_to item_order_path
     else
@@ -53,5 +54,9 @@ class OrdersController < ApplicationController
 
   def set_item
     @item = Item.find(params[:item_id])
+  end
+
+  def move_to_index
+    redirect_to root_path unless user_signed_in?
   end
 end

--- a/app/controllers/orders_controller.rb
+++ b/app/controllers/orders_controller.rb
@@ -1,8 +1,8 @@
 class OrdersController < ApplicationController
   require 'payjp'
   
+  before_action :move_to_user_registration
   before_action :set_order, only: [:show, :update]
-  before_action :move_to_index
   before_action :set_item, only: [:new, :create, :update]
 
   # 商品購入確認ページ
@@ -56,7 +56,7 @@ class OrdersController < ApplicationController
     @item = Item.find(params[:item_id])
   end
 
-  def move_to_index
-    redirect_to root_path unless user_signed_in?
+  def move_to_user_registration
+    redirect_to new_user_registration_path unless user_signed_in?
   end
 end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,4 +1,5 @@
 class UsersController < ApplicationController
+  before_action :move_to_index
   before_action :set_orders, except: [:exhibitor_sale, :exhibitor_progress, :exhibitor_complete, :logout]
   before_action :set_items, only: [:exhibitor_sale, :exhibitor_progress, :exhibitor_complete]
 
@@ -36,5 +37,9 @@ class UsersController < ApplicationController
 
   def set_items
     @items = Item.joins("LEFT OUTER JOIN orders ON items.id = orders.item_id").where('items.user_id = ?', current_user.id).order(created_at: "DESC")
+  end
+
+  def move_to_index
+    redirect_to root_path unless user_signed_in?
   end
 end

--- a/app/views/cards/new.html.haml
+++ b/app/views/cards/new.html.haml
@@ -2,7 +2,7 @@
   カード情報の登録
 .cardinfo_form
   %label カード番号
-  = text_field_tag 'number', '', placeholder: '半角数字のみ', maxlength: '16'
+  = text_field_tag 'number', '', placeholder: '半角数字のみ', maxlength: '16', class: :cardinfo_text
   %br
   %label 有効期限
   = select_tag :exp_month, options_for_select([['01', 1], ['02', 2], ['03', 3], ['04', 4], ['05', 5], ['06', 6], ['07', 7], ['08', 8], ['09', 9], ['10', 10], ['11', 11], ['12', 12]]), {prompt: '--'}
@@ -11,7 +11,7 @@
   %span 年
   %br
   %label セキュリティコード
-  = text_field_tag 'cvc', '', placeholder: 'カード背面3〜4桁の番号', maxlength: '4'
+  = text_field_tag 'cvc', '', placeholder: 'カード背面3〜4桁の番号', maxlength: '4', class: :cardinfo_text
   = form_tag cards_path, method: :post, name: 'inputForm' do
     = hidden_field_tag :payjp_token
     %br

--- a/app/views/items/show.html.haml
+++ b/app/views/items/show.html.haml
@@ -15,14 +15,14 @@
         = "¥#{@item.price.to_s(:delimited, delimiter: ',')}"
       .detail-box-price__sub (税込) 送料込み
     .detail-box-action
-      - if user_signed_in? && current_user.id == @item.user_id
+      - if @item.status > 0
+        = link_to root_path, class: :"detail-box-action__link" do
+          .detail-box-action__button.detail-box-action__button--red この商品は完売しました
+      - elsif user_signed_in? && current_user.id == @item.user_id
         = link_to edit_item_path(@item), class: :"detail-box-action__link" do
           .detail-box-action__button 商品の編集
         = link_to item_path(@item), method: :delete, class: :"detail-box-action__link", data: {confirm: "削除しますか？"} do
           .detail-box-action__button.detail-box-action__button--gray この商品を削除する
-      - elsif @item.status == 1
-        = link_to root_path, class: :"detail-box-action__link" do
-          .detail-box-action__button.detail-box-action__button--red この商品は完売しました
       - else
         = link_to new_item_order_path(@item), class: :"detail-box-action__link" do
           .detail-box-action__button 購入画面に進む


### PR DESCRIPTION
# What
商品編集画面に、出品者のみがアクセスできるようにする。
取引画面に、出品者及び購入者のみがアクセスできるようにする。
アクセス制限の詳細は添付の一覧表を参照。

# Why
出品した商品について、他のユーザーから編集及び削除をされることを防止するため。
取引した商品や送付先住所などを、他のユーザーが閲覧することを防止するため
