### PR TITLE
【修正】商品詳細ページの下の商品表示&取引終了商品非表示設定+α

### DIFF
--- a/app/assets/stylesheets/_details.scss
+++ b/app/assets/stylesheets/_details.scss
@@ -7,6 +7,29 @@ $light_gray: #f8f8f8;
   color: $color;
 }
 
+@mixin product-sold {
+  border-color: #C52F24 transparent transparent transparent;
+  border-style: solid;
+  border-width: 60px 60px 0 0;
+  content: "";
+  height: 0;
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 0;
+  z-index: 2;
+}
+@mixin product-sold__after {
+  color: #fff;
+  content: "SOLD";
+  font-size: 15px;
+  position: absolute;
+  bottom: 30px;
+  left: 0;
+  transform: rotate(-45deg);
+  z-index: 3;
+}
+
 .details {
   width: 100%;
   height: 100%;
@@ -193,21 +216,26 @@ $light_gray: #f8f8f8;
   }
 }
 
+.detail-category-item__link {
+  @include fo_nodec_col($light_green);
+  font-size: 22px;
+  font-weight: bold;
+  padding-left: 300px;
+}
 .detail-category-items {
   width: 700px;
   margin: 0 auto;
+  display: flex;
+  justify-content: start;
+  overflow-x: auto;
   &__head {
     font-size: 22px;
     font-weight: bold;
     margin-bottom: 10px;
   }
-  &__link {
-    @include fo_nodec_col($light_green);
-  }
   &__container {
     display: flex;
     flex-wrap: wrap;
-    width: 720px;
   }
   &__box {
     width: 220px;
@@ -215,12 +243,19 @@ $light_gray: #f8f8f8;
     margin-right: 20px;
     margin-bottom: 20px;
     background-color: $white;
+    position: relative;
     @include fo_nodec_col(#000000);
   }
   &__photo {
     width: 100%;
     height: 220px;
     object-fit: cover;
+    &--sold {
+      @include product-sold
+    }
+    &--sold:after {
+      @include product-sold__after
+    }
   }
   &__content {
     width: 100%;

--- a/app/assets/stylesheets/_toppage.scss
+++ b/app/assets/stylesheets/_toppage.scss
@@ -447,6 +447,9 @@ body {
           
             }
           }
+          &__none {
+            display: none;
+          }
         }
       }
     }

--- a/app/controllers/categories_controller.rb
+++ b/app/controllers/categories_controller.rb
@@ -7,7 +7,7 @@ class CategoriesController < ApplicationController
   # カテゴリ詳細画面
   def show
     @category = Category.find(params[:id])
-    @items = Item.includes(:images).where(category_id: @category.subtree_ids).order("id ASC")
+    @items = Item.includes(:images).where(category_id: @category.subtree_ids).order("id ASC").where.not(status: "2")
   end
 
   private

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -3,7 +3,7 @@ class ItemsController < ApplicationController
 
   # トップページ
   def index
-    @items = Item.all.includes(:images)
+    @items = Item.all.includes(:images).where.not(status: "2")
   end
 
   # 商品出品ページ
@@ -25,8 +25,8 @@ class ItemsController < ApplicationController
 
   # 商品詳細ページ
   def show
-    @item = Item.find(params[:id])
     @category = Category.find(params[:id])
+    @items = Item.includes(:images).where(category_id: @item.category.subtree_ids).order("id ASC").where.not(status: "2")
   end
 
   # 商品情報編集ページ

--- a/app/views/cards/new.html.haml
+++ b/app/views/cards/new.html.haml
@@ -1,3 +1,5 @@
+- content_for(:html_title) {"クレジットカード情報登録 - FreemarketSample65a"}
+
 .cardinfo
   カード情報の登録
 .cardinfo_form

--- a/app/views/cards/show.html.haml
+++ b/app/views/cards/show.html.haml
@@ -1,3 +1,5 @@
+- content_for(:html_title) {"クレジットカード情報確認・削除 - FreemarketSample65a"}
+
 .cardinfo-confirm
   カード情報の確認・削除
 .cardinfo-delete

--- a/app/views/categories/index.html.haml
+++ b/app/views/categories/index.html.haml
@@ -1,3 +1,5 @@
+- content_for(:html_title) {"カテゴリ一覧 - FreemarketSample65a"}
+
 - breadcrumb :category_list
 = render 'shared/nav_bar'
 .categories

--- a/app/views/categories/show.html.haml
+++ b/app/views/categories/show.html.haml
@@ -1,3 +1,5 @@
+- content_for(:html_title) {"#{@category.category}の商品一覧(#{@category.root.category}) - FreemarketSample65a"}
+
 - breadcrumb :category_show, @category
 = render 'shared/nav_bar'
 .categories-list

--- a/app/views/devise/registrations/create_address.html.haml
+++ b/app/views/devise/registrations/create_address.html.haml
@@ -1,3 +1,5 @@
+- content_for(:html_title) {"ユーザー登録完了 - FreemarketSample65a"}
+
 .User-Account-page
   .User-Account-page__content
     .User-contents

--- a/app/views/devise/registrations/new.html.haml
+++ b/app/views/devise/registrations/new.html.haml
@@ -1,4 +1,5 @@
 -# ログイン画面
+- content_for(:html_title) {"新規会員登録(1/2) - FreemarketSample65a"}
 .User-Account-page
   .User-Account-page__content
     .User-contents

--- a/app/views/devise/registrations/new_address.html.haml
+++ b/app/views/devise/registrations/new_address.html.haml
@@ -1,3 +1,5 @@
+- content_for(:html_title) {"新規会員登録(2/2) - FreemarketSample65a"}
+
 .User-Account-page
   .User-Account-page__content
     .User-contents

--- a/app/views/devise/sessions/new.html.haml
+++ b/app/views/devise/sessions/new.html.haml
@@ -1,4 +1,5 @@
 -# 新規登録
+- content_for(:html_title) {"新規会員登録 - FreemarketSample65a"}
 .User-Account-page
   .User-Account-page__content
     .User-contents

--- a/app/views/items/edit.html.haml
+++ b/app/views/items/edit.html.haml
@@ -1,3 +1,5 @@
+- content_for(:html_title) {"商品編集 - FreemarketSample65a"}
+
 - breadcrumb :item_edit
 = render 'shared/nav_bar'
 = render partial: 'form', locals: {submit_value: "変更する"}

--- a/app/views/items/new.html.haml
+++ b/app/views/items/new.html.haml
@@ -1,3 +1,5 @@
+- content_for(:html_title) {"出品する - FreemarketSample65a"}
+
 - breadcrumb :exhibition
 = render 'shared/nav_bar'
 = render partial: 'form', locals: {submit_value: "出品する"}

--- a/app/views/items/searches/index.html.haml
+++ b/app/views/items/searches/index.html.haml
@@ -1,3 +1,5 @@
+- content_for(:html_title) {"#{@keyword}の検索結果 - FreemarketSample65a"}
+
 .main
   .pickup-categories
     .head

--- a/app/views/items/show.html.haml
+++ b/app/views/items/show.html.haml
@@ -1,3 +1,5 @@
+- content_for(:html_title) {"#{@item.name}(¥#{@item.price}) - FreemarketSample65a"}
+
 - breadcrumb :item_show
 = render 'shared/nav_bar'
 .details
@@ -95,27 +97,23 @@
     = link_to '#', class: :"detail-link__text" do
       次の商品
       = icon 'fa', 'angle-right'
+  - if @item.category.is_childless? && @item.category.has_parent? # 自身に子がいない かつ 親がいる = 孫カテゴリまで登録した場合
+    = link_to "#{@item.category.root.category}・#{@item.category.parent.category}・#{@item.category.category}をもっと見る", category_path(@item.category_id), class: :"detail-category-item__link"
+  - elsif @item.category.has_parent? && @item.category.has_children? # 自身に子がいる かつ 親がいる = 子カテゴリまで登録した場合
+    = link_to "#{@item.category.root.category}・#{@item.category.category}をもっと見る", category_path(@item.category_id), class: :"detail-category-item__link"
+  - else # 上記に当てはまらない = 親カテゴリのみ登録した場合
+    = link_to "#{@item.category.category}をもっと見る", category_path(@item.category_id), class: :"detail-category-item__link"
   .detail-category-items
     .detail-category-items__head
-      = link_to '家電・スマホ・カメラをもっと見る', '#', class: :"detail-category-items__link"
-    .detail-category-items__container
-      = link_to item_path(1), class: :"detail-category-items__box" do
-        = image_tag '/temp/a001.png', alt: 'main_photo', class: :"detail-category-items__photo"
-        .detail-category-items__content
-          .detail-category-items__content--name Curry Rice
-          .detail-category-items__content--price ¥880
-      = link_to item_path(1), class: :"detail-category-items__box" do
-        = image_tag '/temp/a001.png', alt: 'main_photo', class: :"detail-category-items__photo"
-        .detail-category-items__content
-          .detail-category-items__content--name Curry Rice
-          .detail-category-items__content--price ¥880
-      = link_to item_path(1), class: :"detail-category-items__box" do
-        = image_tag '/temp/a001.png', alt: 'main_photo', class: :"detail-category-items__photo"
-        .detail-category-items__content
-          .detail-category-items__content--name Curry Rice
-          .detail-category-items__content--price ¥880
-      = link_to item_path(1), class: :"detail-category-items__box" do
-        = image_tag '/temp/a001.png', alt: 'main_photo', class: :"detail-category-items__photo"
-        .detail-category-items__content
-          .detail-category-items__content--name Curry Rice
-          .detail-category-items__content--price ¥880
+    - @items.each do |item|
+      .detail-category-items__container
+        = link_to item_path(item.id), class: :"detail-category-items__box" do
+          = image_tag item.images.first.url.url, alt: "商品画像", class: :"detail-category-items__photo"
+          - if item.status == 1  # 売買状態が、売却済みの場合
+            .detail-category-items__photo--sold
+          .detail-category-items__content
+            .detail-category-items__content--name
+              = item.name
+            .detail-category-items__content--price
+              %ul
+                %li= "#{item.price}円"

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -1,8 +1,9 @@
 !!!
 %html
   %head
-    %meta{:content => "text/html; charset=UTF-8", "http-equiv" => "Content-Type"}/
-    %title FreemarketSample65a
+    %meta{content: "text/html; charset=UTF-8", "http-equiv": "Content-Type"}/
+    %title
+      = content_for?(:html_title) ? yield(:html_title) : "FreemarketSample65a"
     %script{src: "https://js.pay.jp/", type: "text/javascript"}
     = csrf_meta_tags
     = csp_meta_tag

--- a/app/views/orders/create.html.haml
+++ b/app/views/orders/create.html.haml
@@ -1,3 +1,5 @@
+- content_for(:html_title) {"お買い上げありがとうございます - FreemarketSample65a"}
+
 .buy-end
   .buy-end__text
     = link_to root_path, class: "buy-end__text" do

--- a/app/views/orders/new.html.haml
+++ b/app/views/orders/new.html.haml
@@ -1,3 +1,5 @@
+- content_for(:html_title) {"購入画面 - FreemarketSample65a"}
+
 .buy-confirm
   %h2.buy-confirm__buy-head
     購入内容の確認

--- a/app/views/orders/show.html.haml
+++ b/app/views/orders/show.html.haml
@@ -1,3 +1,5 @@
+- content_for(:html_title) {"取引画面 - FreemarketSample65a"}
+
 .trans
   .trans-wrap
     .trans-main

--- a/app/views/users/exhibitor_complete.html.haml
+++ b/app/views/users/exhibitor_complete.html.haml
@@ -1,2 +1,4 @@
+- content_for(:html_title) {"出品した商品 - FreemarketSample65a"}
+
 - breadcrumb :exhibitor_complete
 = render partial: 'exhibitor', locals: {tab_index: 3}

--- a/app/views/users/exhibitor_progress.html.haml
+++ b/app/views/users/exhibitor_progress.html.haml
@@ -1,2 +1,4 @@
+- content_for(:html_title) {"出品した商品 - FreemarketSample65a"}
+
 - breadcrumb :exhibitor_progress
 = render partial: 'exhibitor', locals: {tab_index: 2}

--- a/app/views/users/exhibitor_sale.html.haml
+++ b/app/views/users/exhibitor_sale.html.haml
@@ -1,2 +1,4 @@
+- content_for(:html_title) {"出品した商品 - FreemarketSample65a"}
+
 - breadcrumb :exhibitor_sale
 = render partial: 'exhibitor', locals: {tab_index: 1}

--- a/app/views/users/index.html.haml
+++ b/app/views/users/index.html.haml
@@ -1,3 +1,5 @@
+- content_for(:html_title) {"#{current_user.nickname}さんのマイページ - FreemarketSample65a"}
+
 - breadcrumb :mypage
 = render 'shared/nav_bar'
 .mypage

--- a/app/views/users/info_notice.html.haml
+++ b/app/views/users/info_notice.html.haml
@@ -1,2 +1,4 @@
+- content_for(:html_title) {"お知らせ - FreemarketSample65a"}
+
 - breadcrumb :info_notice
 = render partial: 'info', locals: {tab_index: 1}

--- a/app/views/users/info_todo.html.haml
+++ b/app/views/users/info_todo.html.haml
@@ -1,2 +1,4 @@
+- content_for(:html_title) {"やることリスト - FreemarketSample65a"}
+
 - breadcrumb :info_todo
 = render partial: 'info', locals: {tab_index: 2}

--- a/app/views/users/logout.html.haml
+++ b/app/views/users/logout.html.haml
@@ -1,3 +1,5 @@
+- content_for(:html_title) {"ログアウト確認画面 - FreemarketSample65a"}
+
 - breadcrumb :logout
 = render 'shared/nav_bar'
 .mypage

--- a/app/views/users/purchase_complete.html.haml
+++ b/app/views/users/purchase_complete.html.haml
@@ -1,2 +1,4 @@
+- content_for(:html_title) {"過去の取引 - FreemarketSample65a"}
+
 - breadcrumb :purchase_complete
 = render partial: 'purchase', locals: {tab_index: 2}

--- a/app/views/users/purchase_progress.html.haml
+++ b/app/views/users/purchase_progress.html.haml
@@ -1,2 +1,4 @@
+- content_for(:html_title) {"過去の取引 - FreemarketSample65a"}
+
 - breadcrumb :purchase_progress
 = render partial: 'purchase', locals: {tab_index: 1}


### PR DESCRIPTION
#what
・商品詳細ページのカテゴリ別商品一覧表示を実装。
　→ items/show.html.haml

・取引が終了した商品(itemsのstatus = 2 の商品)を非表示にした。
　→ items.controller.rb および categories.controller.rb

・【+α】各ページのタイトルを暫定的に実装した
　→ layout/application.html.haml
　→【各ページ最上部】以下を記載
　　　- content_for(:html_title) {"「タイトル」"}

#why
カテゴリ別に商品を表示する枠えお有効に活用させるため
購入が済み、取引が終了した商品を再び購入する…ということが起こらないようにするため
ページタイトルをつけることで、自分がどのページにいるのかを可視化できるようにするため

参考（商品一覧）
[![Screenshot from Gyazo](https://gyazo.com/f50d852ad45120baac0117db89f109d4/raw)](https://gyazo.com/f50d852ad45120baac0117db89f109d4)

MySQL
(status=2)「【レディース向け】ポロシャツ3枚セット」を非表示
[![Screenshot from Gyazo](https://gyazo.com/2b87059f1afe410b2b16b0717d4b01dd/raw)](https://gyazo.com/2b87059f1afe410b2b16b0717d4b01dd)