### PR TITLE
商品購入機能の修正

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -26,7 +26,6 @@ class ItemsController < ApplicationController
 
   # 商品詳細ページ
   def show
-    @category = Category.find(params[:id])
     @items = Item.includes(:images).where(category_id: @item.category.subtree_ids).order("id ASC").where.not(status: "2")
   end
 

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -26,6 +26,7 @@ class ItemsController < ApplicationController
 
   # 商品詳細ページ
   def show
+    @category = Category.find(params[:id])
     @items = Item.includes(:images).where(category_id: @item.category.subtree_ids).order("id ASC").where.not(status: "2")
   end
 

--- a/app/controllers/orders_controller.rb
+++ b/app/controllers/orders_controller.rb
@@ -7,13 +7,17 @@ class OrdersController < ApplicationController
 
   # 商品購入確認ページ
   def new
-    card = Card.where(user_id: current_user.id).first
-    if card.blank?
-      redirect_to new_card_path
+    if current_user.id == @item.user_id
+      redirect_to root_path
     else
-      Payjp.api_key = ENV["PAYJP_PRIVATE_KEY"]
-      customer = Payjp::Customer.retrieve(card.customer_id)
-      @card_info = customer.cards.retrieve(card.credit_id)
+      card = Card.where(user_id: current_user.id).first
+      if card.blank?
+        redirect_to new_card_path
+      else
+        Payjp.api_key = ENV["PAYJP_PRIVATE_KEY"]
+        customer = Payjp::Customer.retrieve(card.customer_id)
+        @card_info = customer.cards.retrieve(card.credit_id)
+      end
     end
   end
 

--- a/app/views/orders/new.html.haml
+++ b/app/views/orders/new.html.haml
@@ -36,5 +36,9 @@
           %div= "カード情報:" + "**** **** **** " + @card_info.last4
           %div= "有効期限:" + @card_info.exp_month.to_s + ' / ' + @card_info.exp_year.to_s                
           .buy-confirm__buy-item2__inner__form__user-info
+          - if @item.status == 0
             = link_to item_orders_path(@item), method: :post, class: "buy-confirm__buy-item2__inner__form__user-info__btn-link", data: {confirm: "購入しますか？"} do
-              .buy-confirm__buy-item2__inner__form__user-info__btn-link 購入する          
+              .buy-confirm__buy-item2__inner__form__user-info__btn-link 購入する
+          - else          
+            = link_to root_path, class: "buy-confirm__buy-item2__inner__form__user-info__soldout-link" do
+              .buy-confirm__buy-item2__inner__form__user-info__soldout-link この商品は完売しました


### PR DESCRIPTION
＃WHAT
商品購入機能において
・ユーザーが自ら出品した商品の購入画面にURLを変更して入ろうとしてもトップページに飛ぶように実装しました。
・同じ商品が２度購入されないように一応修正しました。

＃WHY
自ら出品した商品を購入できないようにする為
同じ商品を2度購入できないようにする為
