### PR TITLE
@category = Category.find(params[:id])の削除

### DIFF
--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -6,7 +6,6 @@ class CommentsController < ApplicationController
       redirect_to item_path(@comment.item)
     else
       @item = Item.find(params[:item_id])
-      @category = Category.find(params[:item_id])
       @items = Item.includes(:images).where(category_id: @item.category.subtree_ids).order("id ASC").where.not(status: "2")
       flash.now[:alert] = @comment.errors.full_messages
       render "items/show"

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -28,7 +28,6 @@ class ItemsController < ApplicationController
   def show
     @comments = @item.comments
     @comment = Comment.new
-    @category = Category.find(params[:id])
     @items = Item.includes(:images).where(category_id: @item.category.subtree_ids).order("id ASC").where.not(status: "2")
   end
 


### PR DESCRIPTION
＃WHAT
下記箇所について@category = Category.find(params[:id])の記述削除
① items_controller.rbの31行目（showメソッド）
② comments_controller.rbの９行目（createメソッドのエラー時のrender部分）

＃WHY
①カテゴリテーブルのデータよりもアイテムテーブルのデータが多い場合、商品詳細ページに遷移する際にエラーが起きてしまう為
②記述が不要の為