### PR TITLE
商品検索Lv1の修正（status == 2 の場合は表示しない）

### DIFF
--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -17,8 +17,8 @@ class Item < ApplicationRecord
   enum condition: [:'新品、未使用', :'未使用に近い', :'目立った傷や汚れなし', :'やや傷や汚れあり', :'傷や汚れあり', :'全体的に状態が悪い']
 
   def self.search(search)
-    return Item.all unless search
+    return Item.where.not(status: 2) unless search
     search = "%#{search}%"
-    Item.find_by_sql(["select * from items where text like ? or name like ?", search, search])
+    Item.find_by_sql(["select * from items where items.status < 2 and (text like ? or name like ?)", search, search])
   end
 end


### PR DESCRIPTION
# What
商品検索結果のうち、取引が終了した商品 (status == 2)を表示しないようにする。
修正したファイルは、app/models/item.rb である。

# Why
取引が終了した商品までもが検索結果に表示され続けると、購入不可能な商品ばかりが提示されることになるため。